### PR TITLE
Fix GitHub Actions workflow failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     - name: Checkout Source

--- a/core/src/commands.rs
+++ b/core/src/commands.rs
@@ -23,7 +23,7 @@ pub fn hazard() -> Result<()> {
 /// Show the configuration file
 pub fn config() -> Result<()> {
     let config = AppConfig::fetch()?;
-    println!("{:#?}", config);
+    println!("{config:#?}");
 
     Ok(())
 }

--- a/utils/src/app_config.rs
+++ b/utils/src/app_config.rs
@@ -96,16 +96,16 @@ impl AppConfig {
                     continue; // Handle database section separately
                 }
                 if k == "debug" {
-                    toml_string.push_str(&format!("{} = {}\n", k, v));
+                    toml_string.push_str(&format!("{k} = {v}\n"));
                 } else {
-                    toml_string.push_str(&format!("{} = \"{}\"\n", k, v));
+                    toml_string.push_str(&format!("{k} = \"{v}\"\n"));
                 }
             }
 
             // Add database section
             toml_string.push_str("\n[database]\n");
             if let Some(url) = temp_map.get("database.url") {
-                toml_string.push_str(&format!("url = \"{}\"\n", url));
+                toml_string.push_str(&format!("url = \"{url}\"\n"));
             }
 
             // Build new config


### PR DESCRIPTION
## Summary
- Fixed clippy format string warnings in `utils/src/app_config.rs` (lines 99, 101, 108)
- Added `contents: write` permission to build workflow to resolve release creation failures

## Test plan
- [x] Verified clippy warnings are resolved with `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Confirmed build workflow permissions are properly configured
- [ ] Monitor GitHub Actions workflow runs after merge

Fixes #1

🤖 Generated with [Claude Code](https://claude.ai/code)